### PR TITLE
fix transaction rendering

### DIFF
--- a/src/views/TransactionPage.vue
+++ b/src/views/TransactionPage.vue
@@ -55,8 +55,8 @@ export default {
       const data = await this.$store.dispatch("apiRequest", {
         url: "/transaction",
       });
-      this.transaction = get(data, "0", {});
-      this.events = get(data, "0.events", []);
+      this.transaction = data || {};
+      this.events = get(data, "events", []);
     },
     simVoid: async function () {
       await this.$store.dispatch("apiRequest", {


### PR DESCRIPTION
Honestly not sure how this broke in #13.  In any case, the code was assuming a single transaction was coming back as a list when it was just the request body itself.

~~Will try to debug how it broke between two commits ago and now and report back.~~

Tried the following:
* Revert to the last known good deploy: 1244479d2fa1b2bbf11c848df6adb3ea38ea5ae3
* Use node 14.15 (to match the docker image)
* Fix lint via `npm run lint -- --fix` because it won't build if there are lint errors
* Build the image: `docker-compose build --no-cache`
* Run the stack: `docker-compose up -d`
* Attempt to reproduce the issue - issue still persisted.

My conclusions are thus that either:
- This has been broken for a while and no one noticed (unlikely given how quickly someone noticed when it broke this time), or
- This was somehow broken by a package upgrade, though it's difficult to tell what it would've been since we had no lockfile prior to the latest commit, and I'm not sure who the culprit _could_ be when we're getting the data by hitting our public API directly.

<img width="840" alt="image" src="https://user-images.githubusercontent.com/5304277/236413463-a71bb2ee-c7ba-49ad-9c00-2069c729da93.png">