### PR TITLE
Fix transactions loading

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -68,7 +68,7 @@ const hostedCard = (request, response) => {
   response.send({ displayURL, url, params: { embed_request, hmac } });
 };
 
-app.all("/card", callApi);
+app.all("/cards", callApi);
 app.all("/fundingsource*", callApi);
 app.get("/transaction*", callApi);
 app.post("/simulate/*", callApi);

--- a/src/components/CardModal.vue
+++ b/src/components/CardModal.vue
@@ -56,7 +56,7 @@ export default {
   methods: {
     createCard: async function () {
       const req = {
-        url: "/card",
+        url: "/cards",
         method: "post",
         data: {
           memo: this.memo,

--- a/src/views/ApiKeyPage.vue
+++ b/src/views/ApiKeyPage.vue
@@ -44,7 +44,7 @@ export default {
       e.preventDefault();
       await this.$store.commit("setApiKey", this.apiKey);
       const card = await this.$store.dispatch("apiRequest", {
-        url: "/card",
+        url: "/cards",
         logging: false,
         data: {
           page_size: 1,

--- a/src/views/CardPage.vue
+++ b/src/views/CardPage.vue
@@ -66,7 +66,7 @@ export default {
 
     this.$store
       .dispatch("apiRequest", {
-        url: "/card",
+        url: "/cards",
       })
       .then(([first]) => {
         this.card = first;
@@ -84,7 +84,7 @@ export default {
   methods: {
     getTransactions: async function () {
       this.transactions = await this.$store.dispatch("apiRequest", {
-        url: "/transaction",
+        url: "/transactions",
       });
     },
     simAuth: async function () {

--- a/src/views/CardsPage.vue
+++ b/src/views/CardsPage.vue
@@ -40,7 +40,7 @@ export default {
     },
     getCards: async function () {
       const cards = await this.$store.dispatch("apiRequest", {
-        url: "/card",
+        url: "/cards",
         data: {
           page: this.page,
           page_size: 12,

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -40,7 +40,7 @@ export default {
   created() {
     this.$store
       .dispatch("apiRequest", {
-        url: "/card",
+        url: "/cards",
         data: { page_size: 3 },
       })
       .then((cards) => {
@@ -49,7 +49,7 @@ export default {
 
     this.$store
       .dispatch("apiRequest", {
-        url: "/transaction",
+        url: "/transactions",
         data: { page_size: 11 },
       })
       .then((transactions) => {

--- a/src/views/TransactionPage.vue
+++ b/src/views/TransactionPage.vue
@@ -53,7 +53,7 @@ export default {
   methods: {
     getTransaction: async function () {
       const data = await this.$store.dispatch("apiRequest", {
-        url: "/transaction",
+        url: "/transactions",
       });
       this.transaction = data || {};
       this.events = get(data, "events", []);

--- a/src/views/TransactionsPage.vue
+++ b/src/views/TransactionsPage.vue
@@ -4,14 +4,14 @@
       <template v-slot:center>
         <div class="buttons">
           <button
-            :class="{ active: approval_status === 'approvals' }"
-            @click="toggleStatus('approvals')"
+            :class="{ active: approval_status === 'APPROVED' }"
+            @click="toggleStatus('APPROVED')"
           >
             <h2>Transactions</h2>
           </button>
           <button
-            :class="{ active: approval_status === 'declines' }"
-            @click="toggleStatus('declines')"
+            :class="{ active: approval_status === 'DECLINED' }"
+            @click="toggleStatus('DECLINED')"
           >
             <h2>Declines</h2>
           </button>
@@ -33,7 +33,7 @@ export default {
   },
   data() {
     return {
-      approval_status: "approvals",
+      approval_status: "APPROVED",
       transactions: null,
       page: 1,
     };
@@ -41,8 +41,10 @@ export default {
   methods: {
     getTransactions: async function () {
       const transactions = await this.$store.dispatch("apiRequest", {
-        url: `/transaction/${this.approval_status}`,
+        url: `/transactions`,
         data: {
+          result: this.approval_status,
+          page_size: 10,
           page: this.page,
         },
       });


### PR DESCRIPTION
Fix some behavior related to loading transactions in the demo app

* Changes /card and /transaction to use /cards and /transactions respectively
  * The cards change isn't strictly necessary but this gets us consistent with our public docs which we should strive to do
* Uses the appropriate status filter for transactions when filtering for approvals/declines